### PR TITLE
Django3 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,23 @@ In case this documentation is insufficient, or there are other problems with thi
 
 ### Running and Stopping
 
+#### Startup
+
 Run `docker-compose up -d` in the root of this repo to build images for custom containers and start all of the CoGS containers in the background, or to update the containers if they are already running.
+
+#### Database Initialization
+
+The database for this project takes a bit of time to initialize from an empty volume (when cloning the repo for the first time, or after running `docker-compose down -v` or otherwise having an empty `cogs_db` volume). To allow the database to properly initialize, after running `docker-compose up -d` the first time, monitor the database logs with `docker-compose logs -f db` and when it finishes initializing, `docker-compose restart` to allow Django to reconnect.
+
+#### Stopping
 
 To stop the containers, run `docker-compose stop`. To restart them use `docker-compose start`. To stop the containers and delete them, use `docker-compose down`. Note that while this does delete volume connections, it does **not** delete host files created by volumes, so for example the database data in `./data-db` will persist; images from `Dockerfile`s will also need to be manually deleted if they are to be rebuilt.
 
 The `down` subcommand is useful for starting from *almost* scratch, such that only data in volume folders persists, but every container is completely recycled. Running `docker-compose up -d` will start them anew, but does not rebuild images from `Dockerfile`s if they still exist. To rebuild images from `Dockerfile`s use `docker-compose build`. This will force a rebuild of images that are listed in `docker-compose.yml` with a `build:` directory.
 
 To start the database from scratch, remove `./data-db` after `docker-compose down`. When you start up again, the database will create a new `./data-db`. Note that if you do this, the database will be missing some vital default models from Django, so you must migrate the models to the database. In Django, this is done with `python manage.py migrate`. **However**, since Django is running inside the `web` service, you must use `docker-compose exec <service> <command>` or `docker exec <container> <command>`. In this case, that would be `docker-compose exec web python manage.py migrate`.
+
+#### Commands Inside Containers
 
 In general, to run commands in a given service, use `docker-compose exec <service> <command>`. This will probably be very useful to you.
 
@@ -40,5 +50,7 @@ Run these commands to start CoGS (assuming you've installed Docker and Docker Co
 
 ```
 docker-compose up -d
+sleep 1m                # Wait for database to initialize
+docker-compose restart  # Let Django reconnect to the database
 docker-compose exec web python manage.py migrate
 ```

--- a/django/composeexample/settings.py
+++ b/django/composeexample/settings.py
@@ -79,7 +79,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'django',
-        'USER': 'root',
+        'USER': 'MRDC',
         'PASSWORD': 'apricots',
         'HOST': 'db',
         'PORT': 3306

--- a/django/composeexample/settings.py
+++ b/django/composeexample/settings.py
@@ -79,7 +79,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'django',
-        'USER': 'MRDC',
+        'USER': 'mrdc',
         'PASSWORD': 'apricots',
         'HOST': 'db',
         'PORT': 3306

--- a/django/composeexample/settings.py
+++ b/django/composeexample/settings.py
@@ -39,7 +39,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'team_management.apps.TeamManagementConfig',
     'channels',
-    'django_dbconn_retry',
 ]
 
 MIDDLEWARE = [

--- a/django/composeexample/settings.py
+++ b/django/composeexample/settings.py
@@ -75,13 +75,14 @@ ASGI_APPLICATION = "composeexample.routing.application"
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
-
 DATABASES = {
     'default': {
-        'ENGINE': 'djongo',
-        'NAME': 'djongo',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'django',
+        'USER': 'root',
+        'PASSWORD': 'apricots',
         'HOST': 'db',
-        'PORT': 27017
+        'PORT': 3306
     }
 }
 

--- a/django/composeexample/settings.py
+++ b/django/composeexample/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'team_management.apps.TeamManagementConfig',
     'channels',
+    'django_dbconn_retry',
 ]
 
 MIDDLEWARE = [

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -3,4 +3,3 @@ Django>=3.0,<4.0
 psycopg2>=2.7,<3.0
 channels>=2.3,<3.0
 mysqlclient>=1.0,<2.0
-django-dbconn-retry

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,5 +1,5 @@
 sqlparse==0.2.4
-Django>=2.0,<3.0
+Django>=3.0,<4.0
 psycopg2>=2.7,<3.0
 djongo
-channels>=2.3
+channels>=2.3,<3.0

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -3,3 +3,4 @@ Django>=3.0,<4.0
 psycopg2>=2.7,<3.0
 channels>=2.3,<3.0
 mysqlclient>=1.0,<2.0
+django-dbconn-retry

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,5 +1,5 @@
 sqlparse==0.2.4
 Django>=3.0,<4.0
 psycopg2>=2.7,<3.0
-djongo
 channels>=2.3,<3.0
+mysqlclient>=1.0,<2.0

--- a/django/team_management/models.py
+++ b/django/team_management/models.py
@@ -5,9 +5,6 @@ class Blog(models.Model):
     tagline = models.TextField(blank=True)
     author = models.CharField(max_length=50)
 
-    class Meta:
-        abstract = True
-
 class Entry(models.Model):
     blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
     headline = models.CharField(max_length=255)

--- a/django/team_management/models.py
+++ b/django/team_management/models.py
@@ -1,4 +1,4 @@
-from djongo import models
+from django.db import models
 
 class Blog(models.Model):
     name = models.CharField(max_length=100)
@@ -9,9 +9,5 @@ class Blog(models.Model):
         abstract = True
 
 class Entry(models.Model):
-    blog = models.EmbeddedModelField(
-        model_container=Blog,
-    )
-
+    blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
     headline = models.CharField(max_length=255)
-    objects = models.DjongoManager()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,10 @@ services:
   db:
     image: mariadb                  # Tells Compose to use the 'mariadb' image for the 'db' service
     environment:
-      MYSQL_ROOT_HOST: 'host.docker.internal'
-      MYSQL_DATABASE: 'django'
-      MYSQL_USER: 'root'
-      MYSQL_PASSWORD: 'apricots'
-      MYSQL_ROOT_PASSWORD: 'apricots'
+      MYSQL_DATABASE: 'django'      #name of the auto-created database
+      MYSQL_USER: 'MRDC'            #This user getssuperuser privileges on the django database created above
+      MYSQL_PASSWORD: 'apricots'    #password for MRDC user
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     volumes:
       - db:/var/lib/mysql           # Connects /var/lib/mysql in the container to a named Docker volume
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mariadb                  # Tells Compose to use the 'mariadb' image for the 'db' service
     environment:
       MYSQL_DATABASE: 'django'      #name of the auto-created database
-      MYSQL_USER: 'MRDC'            #This user getssuperuser privileges on the django database created above
+      MYSQL_USER: 'mrdc'            #This user getssuperuser privileges on the django database created above
       MYSQL_PASSWORD: 'apricots'    #password for MRDC user
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_PASSWORD: 'apricots'
       MYSQL_ROOT_PASSWORD: 'apricots'
     volumes:
-      - db:/data/db                 # Connects /data/db in the container to a named Docker volume
+      - db:/var/lib/mysql           # Connects /var/lib/mysql in the container to a named Docker volume
   web:
     build: ./django                 # Tells Compose to build the 'web' service from ./django (with Dockerfile)
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,15 @@ version: '3.7'
 
 services:
   db:
-    image: mongo                    # Tells Compose to use the 'mongo' image for the 'db' service
+    image: mariadb                  # Tells Compose to use the 'mariadb' image for the 'db' service
     environment:
-      MONGO_INITDB_DATABASE: djongo # Tells Mongo to initialize a database called 'djongo' on first start
+      MYSQL_ROOT_HOST: 'host.docker.internal'
+      MYSQL_DATABASE: 'django'
+      MYSQL_USER: 'root'
+      MYSQL_PASSWORD: 'apricots'
+      MYSQL_ROOT_PASSWORD: 'apricots'
     volumes:
-      - ./data-db:/data/db          # Connects ./data-db in this repo to /data/db inside the db container
+      - db:/data/db                 # Connects /data/db in the container to a named Docker volume
   web:
     build: ./django                 # Tells Compose to build the 'web' service from ./django (with Dockerfile)
     volumes:
@@ -15,3 +19,6 @@ services:
       - "8000:8000"                 # Binds port 8000 to container port 8000 (format "HOST:CONTAINER")
     depends_on:
       - db                          # Tells Compose that 'db' needs to be started before 'web' can start
+
+volumes:
+  db:


### PR DESCRIPTION
The work on Django 3.0 has been completed. We now use MariaDB (MySQL) instead of MongoDB, to avoid waiting for Djongo to support Django 3.0. The database information is now stored in a Docker volume instead of a local folder.

Unfortunately, the startup process is now slightly more complicated, but this has been documented in the README. A fix for this may be possible but is low priority.